### PR TITLE
Resolves error about empty delimiter 

### DIFF
--- a/cdn-linker-base.php
+++ b/cdn-linker-base.php
@@ -119,11 +119,11 @@ class CDNLinksRewriter
 	 */
 	protected function exclude_single(&$match) {
 		foreach ($this->excludes as $badword) {
-            if ($badword) {
-                if (stristr($match, $badword) != false) {
-                    return true;
-                }
+          if ($badword) {
+            if (stristr($match, $badword) != false) {
+              return true;
             }
+          }
 		}
 		return false;
 	}


### PR DESCRIPTION
Resolves the following error found in the php error logs:

```
"PHP message: PHP Warning:  stristr(): Empty delimiter in /var/www/bridgesinbelize.org/wp-content/plugins/cdn-linker/cdn-linker-base.php on line 122"
```
