### PR TITLE
has_cap error corrected by replacing 8 with manage_options. has_cap is deprecated.

### DIFF
--- a/wp-cdn-linker.php
+++ b/wp-cdn-linker.php
@@ -40,7 +40,7 @@ function ossdl_off_deactivate() {
 add_action('admin_menu', 'ossdl_off_menu');
 
 function ossdl_off_menu() {
-	add_options_page('CDN Linker', 'CDN Linker', manage_options, __FILE__, 'ossdl_off_options');
+	add_options_page('CDN Linker', 'CDN Linker', 'manage_options', __FILE__, 'ossdl_off_options');
 }
 
 function ossdl_off_options() {


### PR DESCRIPTION
Fix for Notice: has_cap was called with an argument that is deprecated since
version 2.0! Usage of user levels by plugins and themes is deprecated.
Use roles and capabilities instead. in
/var/www/html/wp-includes/functions.php on line 2923
