### PR TITLE
Use composer for package management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .komodotools
 mageekguy.atoum.phar
 README.pdf
+
+/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .komodotools
 mageekguy.atoum.phar
 README.pdf
-
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "wmark/cdn-linker",
+    "description": "Modifies links pointing to wp-content and/or wp-includes",
+    "type": "wordpress-plugin",
+    "require": {
+        "php": ">=5.3.0",
+        "composer/installers": "~1.0"
+    },
+    "license": "RPL-1.5",
+    "authors": [
+        {
+            "name": "W. Mark Kubacki",
+            "email": "wmark@hurrikane.de"
+        }
+    ]
+}


### PR DESCRIPTION
What This Fixes
--------------------
The following commit will give consumers the ability to use composer within a
wordpress project. We include composer installers as a requirement to provide
the feature of installing plugins to a custom folder
Next Steps
---------------
After pulling in composer, please register your repo with https://packagist.org. This includes creating an account and enabling auto-update for push hooks in the repo settings. More specifically, allowing you to push and have the package auto-update when composer is ran.

Another thing to implement is a new version. I notice your latest tag release is at 1.4.2. Looking at the commit history, I believe it is time we move the repo up to a 1.5.0 release --since most changes where patches/minor upgrades. Moreover, the latest release does not reflect the past year of commits.

Examples
---------------
Please check out examples of popular plugins that have pulled composer into their development:
- https://github.com/elliotcondon/acf/pull/266
- https://github.com/olefredrik/FoundationPress/pull/392