### PR TITLE
Feat: Filter for adding global excludes

### DIFF
--- a/cdn-linker-base.php
+++ b/cdn-linker-base.php
@@ -225,6 +225,7 @@ function register_as_output_buffer_handler() {
 	}
 
 	$excludes = array_map('trim', explode(',', get_option('ossdl_off_exclude')));
+    $excludes = apply_filters('cdn-linker-global-excludes', $excludes);
 	$rewriter = new URI_changer(
 		get_option('siteurl'),
 		target_url_strategy_for(trim(get_option('ossdl_off_cdn_url'))),


### PR DESCRIPTION
For WP multisites that include a large number of sites it is tedious adding new excludes to each and every site.

This allows new excludes to be added to every site with a few lines of code:

function cdn_linker_excludes($excludes) {
	$excludes[] = '.some-extension';
	return $excludes;
}

add_filter('cdn-linker-global-excludes', 'cdn_linker_excludes');